### PR TITLE
Fix invalid tag

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "default_tags" {
   type = map(string)
   default = {
     ManagedBy = "Terraform"
-    Product   = "Seqera Platform"
+    Product   = "SeqeraPlatform"
   }
   description = "Default tags to be applied to the provisioned resources."
 }


### PR DESCRIPTION
This PR fixes a tag containing a blank character that causes a failure when creating EKS node group

Solve https://github.com/seqeralabs/terraform-seqera-eks/issues/13